### PR TITLE
Fix issue #13 (V0.09 + Win10 系統快速鍵失效)

### DIFF
--- a/server/input_methods/chewing/chewing_config.py
+++ b/server/input_methods/chewing/chewing_config.py
@@ -55,7 +55,7 @@ class ChewingConfig:
         # self.phraseMark = True
         self.escCleanAllBuf = True
         self.easySymbolsWithShift = True
-        self.easySymbolsWithCtrl = True
+        self.easySymbolsWithCtrl = False
         self.upperCaseWithShift = True
 
         # version: last modified time of (config.json, symbols.dat, swkb.dat)


### PR DESCRIPTION
PCMan大大你好：

我發現這問題是因為`PIME\server\input_methods\chewing\chewing_config.py`的`self.easySymbolsWithCtrl`是`True`，但`PIME\server\input_methods\chewing\config\js\config.js`裡的`easySymbolsWithCtrl`是`false`的關係，把兩個調整到一樣就可以解決問題。

