### PR TITLE
add openKeyboard command, and report isKeyboardOpen onActivate

### DIFF
--- a/PIME/PIMEClient.cpp
+++ b/PIME/PIMEClient.cpp
@@ -219,6 +219,9 @@ void Client::updateStatus(Json::Value& msg, Ime::EditSession* session) {
 				}
 			}
 		}
+		else if (value.isBool() && strcmp(name, "openKeyboard") == 0) {
+			textService_->setKeyboardOpen(value.asBool());
+		}
 		// other configurations
 		else if (value.isString() && strcmp(name, "setSelKeys") == 0) {
 			// keys used to select candidates
@@ -287,6 +290,7 @@ void Client::onActivate() {
 	Json::Value req;
 	int sn = addSeqNum(req);
 	req["method"] = "onActivate";
+	req["isKeyboardOpen"] = textService_->isKeyboardOpened();
 
 	Json::Value ret;
 	sendRequest(req, sn, ret);


### PR DESCRIPTION
https://github.com/EasyIME/libIME/blob/d4e6cb41ea7d673a3b679ec9af282cea6e22cd6a/TextService.cpp#L667-L671

我觉得这几行代码应该删掉。不应该在 `TextService::Activate` 时强行打开键盘。因为键盘状态是由系统维护的[1]。

在 Windows 10 测试：如果在其它输入法（例如微软拼音）中切换了键盘状态，再激活 PIME ，键盘状态是保留的，并非如注释中所言会自动关闭。

这个  pr 首先是给 onActivate 消息增加键盘状态的通知。因为无法由 onKeyboardStatusChanged 感知键盘状态，所以需要在 onActivate 时通知 server 。

其次给 server 增加主动打开或关闭键盘的能力。这样，即使需要在 Activate 时强制打开键盘，也可以放在 server 中实现，而不必在 libIME 中写死。

[1] : https://blogs.msdn.microsoft.com/tsfaware/2007/05/30/whats-a-keyboard/
