### PR TITLE
update link of ID_DICT_BUGREPORT(注音及選字選詞錯誤回報)

### DIFF
--- a/server/input_methods/chewing/chewing_ime.py
+++ b/server/input_methods/chewing/chewing_ime.py
@@ -552,7 +552,7 @@ class ChewingTextService(TextService):
         elif commandId == ID_BUGREPORT: # visit bug tracker page
             os.startfile("https://github.com/EasyIME/PIME/issues")
         elif commandId == ID_DICT_BUGREPORT:
-            os.startfile("https://github.com/chewing/libchewing-data/issues")
+            os.startfile("https://github.com/chewing/libchewing/issues")
         elif commandId == ID_MOEDICT: # a very awesome online Chinese dictionary
             os.startfile("https://www.moedict.tw/")
         elif commandId == ID_DICT: # online Chinese dictonary


### PR DESCRIPTION
The latest updated of the dictionary in libchewing-data was 3 years ago, but the dictionary in libchewing is keep updating.

[chewing/libchewing-data](https://github.com/chewing/libchewing-data) looks like deprecated, maybe we should use [chewing/libchewing](https://github.com/chewing/libchewing) instead.
