### PR TITLE
Fix: 判斷第一個字是不是注音符號 & issue#93

### DIFF
--- a/server/input_methods/chewing/chewing_ime.py
+++ b/server/input_methods/chewing/chewing_ime.py
@@ -303,8 +303,7 @@ class ChewingTextService(TextService):
                 return False
 
         # 中文模式下，當中文編輯區是空的，輸入法只需處理注音符號
-        # FIXME: 應該檢查按下的鍵是否為注音，不過大略可用是否為 printable char 代替
-        if keyEvent.isPrintableChar() and keyEvent.keyCode != VK_SPACE:
+        if keyEvent.isBopomofo():
             return True
 
         # 其餘狀況一律不處理，原按鍵輸入直接送還給應用程式
@@ -460,7 +459,7 @@ class ChewingTextService(TextService):
             # 有輸入完成的中文字串要送出(commit)到應用程式
             if chewingContext.commit_Check():
                 commitStr = chewingContext.commit_String().decode("UTF-8")
-                
+
                 # 如果使用打繁出簡，就轉成簡體中文
                 if self.outputSimpChinese:
                     commitStr = self.opencc.convert(commitStr)
@@ -529,7 +528,7 @@ class ChewingTextService(TextService):
     def onCommand(self, commandId, commandType):
         print("onCommand", commandId, commandType)
         # FIXME: We should distinguish left and right click using commandType
-        
+
         if commandId == ID_SWITCH_LANG:  # 切換中英文模式
             self.toggleLanguageMode()
         elif commandId == ID_SWITCH_SHAPE:  # 切換全形/半形
@@ -610,7 +609,7 @@ class ChewingTextService(TextService):
             self.changeButton("switch-lang", icon=icon_path)
 
             if self.client.isWindows8Above: # windows 8 mode icon
-                # FIXME: we need a better set of icons to meet the 
+                # FIXME: we need a better set of icons to meet the
                 #        WIndows 8 IME guideline and UX guidelines.
                 self.changeButton("windows-mode-icon", icon=icon_path)
 

--- a/server/input_methods/chewing/chewing_ime.py
+++ b/server/input_methods/chewing/chewing_ime.py
@@ -475,14 +475,15 @@ class ChewingTextService(TextService):
             if chewingContext.bopomofo_Check():
                 bopomofoStr = ""
                 bopomofoStr = chewingContext.bopomofo_String(None).decode("UTF-8")
-                # 把輸入到一半，還沒組成字的注音字串，也插入到編輯區內
+                # 把輸入到一半，還沒組成字的注音字串，也插入到編輯區內，並且更新游標位置
                 pos = chewingContext.cursor_Current()
                 compStr = compStr[:pos] + bopomofoStr + compStr[pos:]
+                self.setCompositionCursor(chewingContext.cursor_Current() + len(bopomofoStr))
+            else:
+                self.setCompositionCursor(chewingContext.cursor_Current())
 
             # 更新編輯區內容 (composition string)
             self.setCompositionString(compStr)
-            # 更新輸入游標位置
-            self.setCompositionCursor(chewingContext.cursor_Current())
 
             # 顯示額外提示訊息 (例如：Ctrl+數字加入自訂詞之後，會顯示提示)
             if chewingContext.aux_Check():

--- a/server/textService.py
+++ b/server/textService.py
@@ -54,6 +54,10 @@ class KeyEvent:
     def isPrintableChar(self):
         return self.charCode > 0x1f and self.charCode != 0x7f
 
+    def isBopomofo(self):
+        return  (self.charCode >= 0x61 and self.charCode <= 0x7a) or (self.charCode >= 0x30 and self.charCode <= 0x39)\
+         or (self.charCode == 0x3b) or (self.charCode >= 0x2c and self.charCode <= 0x2f)
+
 
 class TextService:
     def __init__(self, client):
@@ -123,7 +127,7 @@ class TextService:
             success = False
 
         return success, ret
-        
+
     # methods that should be implemented by derived classes
     def onActivate(self):
         pass


### PR DESCRIPTION
在server/input_methods/chewing/chewing_ime.py Line305中，
有一個FIXME，要修復當中文編輯區是空的，輸入法只需要處理注音符號。

我在 testService.py 的 class keyEvent中，
新增了isBopomofo()這個function來判斷輸入是不是注音符號，
而我的判斷除了注音符號還包括一聲到四聲與輕聲這五個符號，
只要屬於以上所述的符號，isBopomofo()就會return True，

而在 chewing_ime.py中，將原本只是判斷 isPrintableChar()註解掉，
改以 isBopomofo() 來判斷輸入是不是注音符號與聲調符號。

-------------------
第三個commit 為修復  [Issue#93](https://github.com/EasyIME/PIME/issues/93) 修正輸入注音的游標位置

chewingContext.cursor_Current()  這個function是用來找目前游標位置，
這個游標位置是依照目前還沒送出編輯區內容的國字有幾個而定，
所以當我們只打注音的時候，因為目前編輯區內容沒有任何國字，所以游標位置會在0的位置，
而 self.setCompositionCursor(chewingContext.cursor_Current()) 這行程式碼在每次輸入新的input時候他都會被呼叫，也就導致每次輸入注音時候游標位置一直被移到最前面。

所以當每次 bopomofo_Check() 時候，我們計算目前注音符號的長度，讓游標的位置設定到目前游標再加上注音符號的長度，就可以完成了。
