### PR TITLE
Fixme: Distinguish left and right click

### DIFF
--- a/server/input_methods/chewing/chewing_ime.py
+++ b/server/input_methods/chewing/chewing_ime.py
@@ -530,9 +530,9 @@ class ChewingTextService(TextService):
         print("onCommand", commandId, commandType)
         # FIXME: We should distinguish left and right click using commandType
         
-        if commandId == ID_SWITCH_LANG:  # 切換中英文模式
+        if commandId == ID_SWITCH_LANG and commandType == COMMAND_LEFT_CLICK:  # 切換中英文模式
             self.toggleLanguageMode()
-        elif commandId == ID_SWITCH_SHAPE:  # 切換全形/半形
+        elif commandId == ID_SWITCH_SHAPE and commandType == COMMAND_LEFT_CLICK:  # 切換全形/半形
             self.toggleShapeMode()
         elif commandId == ID_SETTINGS:  # 開啟設定工具
             config_tool = '"{0}"'.format(os.path.join(self.curdir, "config", "configTool.py"))


### PR DESCRIPTION
利用commandType去辨識點擊語言列icon的左右鍵，目前只分辨切換中英文跟全半形兩個的事件

不知道是否全部都需要分辨比較適當？

謝謝