### PR TITLE
onActivate function裡設定下方的FIXME command刪除

### DIFF
--- a/server/input_methods/chewing/chewing_ime.py
+++ b/server/input_methods/chewing/chewing_ime.py
@@ -202,7 +202,6 @@ class ChewingTextService(TextService):
         )
 
         # 設定
-        # FIXME: popup menu is not yet implemented
         self.addButton("settings",
             icon = os.path.join(self.icon_dir, "config.ico"),
             tooltip = "設定",


### PR DESCRIPTION
之前有在https://github.com/EasyIME/PIME/issues/94 
提到發現這個功能已經實做,因為我一開始看到這行註解也在研究看是哪邊沒改好,不過好像功能在以下的commit:https://github.com/EasyIME/PIME/commit/0ee76e2e978006112a6eb8807091da3cb9549977 已實做出來
所以幫忙把註解刪掉,若有人想幫忙貢獻可以趕快從其他方面著手~