### PR TITLE
Modify `SW_SHOWNORMAL` to `SW_HIDE` on ShellExecuteExW.

### DIFF
--- a/PIMELauncher/PIMELauncher.cpp
+++ b/PIMELauncher/PIMELauncher.cpp
@@ -43,7 +43,7 @@ static HANDLE launchProcess(const wchar_t* file, const wchar_t* params, const wc
 	info.lpFile = file;
 	info.lpParameters = params;
 	info.lpDirectory = workingDir;
-	info.nShow = SW_SHOWNORMAL;
+	info.nShow = SW_HIDE;
 	if (ShellExecuteExW(&info))
 		process = info.hProcess;
 	DWORD err = GetLastError();


### PR DESCRIPTION
Prevent node execute with windows.

refe: https://github.com/EasyIME/forum/issues/1