### PR TITLE
[nime] Set UV_THREADPOOL_SIZE to 64 and can service 63 clients

### DIFF
--- a/PIMELauncher/PIMELauncher.cpp
+++ b/PIMELauncher/PIMELauncher.cpp
@@ -51,8 +51,10 @@ static HANDLE launchProcess(const wchar_t* file, const wchar_t* params, const wc
 }
 
 void BackendServer::start() {
-	if(process_ == INVALID_HANDLE_VALUE)
+	if(process_ == INVALID_HANDLE_VALUE){
+		SetEnvironmentVariable(L"UV_THREADPOOL_SIZE", L"64");
 		process_ = launchProcess(command_.c_str(), params_.c_str(), workingDir_.c_str());
+	}
 }
 
 void BackendServer::terminate() {


### PR DESCRIPTION
Because each client would use the one thread and nodejs UV_THREADPOOL_SIZE default is 4.

Only can service 3 client (1 for server). So we need to set UV_THREADPOOL_SIZE environment.

More detail on https://github.com/EasyIME/NIME/issues/7