### PR TITLE
CI: 取消「choco install nsis」

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ init:
 install:
   - git submodule init
   - git submodule update
-  - choco install nsis
 
 build_script:
   - .\build.bat


### PR DESCRIPTION
AppVeyor 環境已自帶 NSIS，無需單獨下載。