### PR TITLE
蝦米：最大碼長 4 碼

### DIFF
--- a/python/input_methods/cheliu/cheliu_ime.py
+++ b/python/input_methods/cheliu/cheliu_ime.py
@@ -35,7 +35,7 @@ class CheLiuTextService(TextService):
 
         # 輸入法模組自訂區域
         self.imeDirName = "cheliu"
-        self.maxCharLength = 5 # 輸入法最大編碼字元數量
+        self.maxCharLength = 4 # 輸入法最大編碼字元數量
         self.cinFileList = ["liu.json"]
 
         self.cinbase = CinBase


### PR DESCRIPTION
嘸蝦米中每個字最多取 4 碼。