### PR TITLE
Allow switch lang with only left or right shift

### DIFF
--- a/python/cinbase/config.py
+++ b/python/cinbase/config.py
@@ -23,6 +23,10 @@ import shutil
 
 DEF_FONT_SIZE = 12
 
+SWITCH_LANG_WITH_BOTH_SHIFT = 0
+SWITCH_LANG_WITH_LEFT_SHIFT = 1
+SWITCH_LANG_WITH_RIGHT_SHIFT = 2
+
 selKeys=(
     "1234567890"
 )
@@ -35,6 +39,7 @@ class CinBaseConfig:
         self.defaultFullSpace = False
         self.disableOnStartup = False
         self.switchLangWithShift = True
+        self.switchLangWithWhichShift = SWITCH_LANG_WITH_BOTH_SHIFT
         self.outputSmallLetterWithShift = False
         self.switchPageWithSpace = False
         self.outputSimpChinese = False

--- a/python/cinbase/config/config.htm
+++ b/python/cinbase/config/config.htm
@@ -110,6 +110,10 @@
                             <input type="checkbox" id="switchLangWithShift" name="switchLangWithShift" />
                             <label for="switchLangWithShift">使用 Shift 快速切換中英文</label><br />
 
+                            <label for="switchLangWithWhichShift">使用哪一邊的 Shift 來切換中英文模式: </label>
+                            <select name="switchLangWithWhichShift" id="switchLangWithWhichShift"></select>
+                            <br />
+
                             <input type="checkbox" id="autoClearCompositionChar" name="autoClearCompositionChar" />
                             <label for="autoClearCompositionChar">拆錯字碼時自動清除輸入字串</label><br />
 

--- a/python/cinbase/config/css/config.css
+++ b/python/cinbase/config/css/config.css
@@ -30,6 +30,10 @@
     cursor: pointer;
 }
 
+select[disabled] {
+    cursor: not-allowed;
+}
+
 
 /* Bootstrap */
 /* ================================================================== */

--- a/python/cinbase/config/js/config.js
+++ b/python/cinbase/config/js/config.js
@@ -451,6 +451,19 @@ function pageReady() {
     $("#candMaxItems").TouchSpin({min:100, max:10000});
     $("#fontSize").TouchSpin({min:6, max:200});
 
+    var selWhichShift = [
+        "左右兩邊都使用",
+        "僅使用左 Shift",
+        "僅使用右 Shift"
+    ];
+    var switchLangWithWhichShift = $("#switchLangWithWhichShift");
+    for(var i = 0; i < selWhichShift.length; ++i) {
+        var selWhichShiftOption = selWhichShift[i];
+        var item = '<option value="' + i + '">' + selWhichShiftOption + '</option>';
+        switchLangWithWhichShift.append(item);
+    }
+    switchLangWithWhichShift.children().eq(checjConfig.switchLangWithWhichShift).prop("selected", true);
+
     var selMessageTimes=[
         "０　",
         "１　",
@@ -590,6 +603,14 @@ function pageReady() {
             item.val(value);
             break;
         }
+    });
+
+    // setup switchLangWithWhichShift default disabled property
+    $("#switchLangWithWhichShift").prop("disabled", !checjConfig["switchLangWithShift"]);
+
+    // when switchLangWithShift changes, update switchLangWithWhichShift disabled property
+    $("#switchLangWithShift").on("click", function() {
+        $("#switchLangWithWhichShift").prop("disabled", !this.checked);
     });
 
     // use for select example

--- a/python/input_methods/chearray/config/config.json
+++ b/python/input_methods/chearray/config/config.json
@@ -7,6 +7,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/checj/config/config.json
+++ b/python/input_methods/checj/config/config.json
@@ -1,5 +1,6 @@
 {
   "switchLangWithShift": true,
+  "switchLangWithWhichShift": 0,
   "selRCinType": 0,
   "selCinType": 0,
   "selWildcardType": 1,

--- a/python/input_methods/chedayi/config/config.json
+++ b/python/input_methods/chedayi/config/config.json
@@ -8,6 +8,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/cheez/config/config.json
+++ b/python/input_methods/cheez/config/config.json
@@ -7,6 +7,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/cheliu/config/config.json
+++ b/python/input_methods/cheliu/config/config.json
@@ -7,6 +7,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/chephonetic/config/config.json
+++ b/python/input_methods/chephonetic/config/config.json
@@ -7,6 +7,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/chepinyin/config/config.json
+++ b/python/input_methods/chepinyin/config/config.json
@@ -7,6 +7,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/chesimplex/config/config.json
+++ b/python/input_methods/chesimplex/config/config.json
@@ -7,6 +7,7 @@
     "defaultFullSpace": false,
     "selCinType": 0,
     "switchLangWithShift": true,
+    "switchLangWithWhichShift": 0,
     "outputSmallLetterWithShift": false,
     "switchPageWithSpace": false,
     "fullShapeSymbols": false,

--- a/python/input_methods/chewing/chewing_config.py
+++ b/python/input_methods/chewing/chewing_config.py
@@ -22,6 +22,10 @@ import shutil
 
 DEF_FONT_SIZE = 16
 
+SWITCH_LANG_WITH_BOTH_SHIFT = 0
+SWITCH_LANG_WITH_LEFT_SHIFT = 1
+SWITCH_LANG_WITH_RIGHT_SHIFT = 2
+
 # from libchewing/include/internal/userphrase-private.h
 DB_NAME = "chewing.sqlite3"
 
@@ -62,6 +66,7 @@ class ChewingConfig:
         self.spaceKeyAction = 1
         self.spaceKeyCandidatesAction = 0
         self.switchLangWithShift = True
+        self.switchLangWithWhichShift = SWITCH_LANG_WITH_BOTH_SHIFT
         self.upDownAction = 0
         self.upperCaseWithShift = True
         self.disableOnStartup = False

--- a/python/input_methods/chewing/config_tool.html
+++ b/python/input_methods/chewing/config_tool.html
@@ -108,6 +108,10 @@
                                 <label class="custom-control-label" for="switchLangWithShift" data-content="不建議同時使用「<b>使用左 Shift、 右 Shift 在打字時移動游標</b>」設定"
                                     data-html="true" data-toggle="popover" data-placement="bottom" data-trigger="hover">使用<kbd>Shift</kbd>切換中英文模式 🛈</label>
                             </div>
+                            <div class="custom-control position-static">
+                                使用哪一邊的<kbd>Shift</kbd>來切換中英文模式：
+                                <select name="switchLangWithWhichShift" id="switchLangWithWhichShift"></select>
+                            </div>
                             <div class="custom-control custom-checkbox">
                                 <input type="checkbox" class="custom-control-input" id="enableCapsLock" name="enableCapsLock">
                                 <label class="custom-control-label" for="enableCapsLock">使用<kbd>CapsLock</kbd>切換中英文模式</label>

--- a/python/input_methods/chewing/js/config.js
+++ b/python/input_methods/chewing/js/config.js
@@ -142,6 +142,11 @@ $(function() {
 
         // Setup select options and values
         let selectOptions = {
+            "switchLangWithWhichShift": [
+                "左右兩邊都使用",
+                "僅使用左 Shift",
+                "僅使用右 Shift"
+            ],
             "upDownAction": [
                 "移動游標選字",
                 "在選字時翻頁"
@@ -181,9 +186,17 @@ $(function() {
             });
         });
 
+        // Setup switchLangWithWhichShift's default disabled property
+        $("#switchLangWithWhichShift").prop("disabled", !chewingConfig["switchLangWithShift"])
+
         // Bind Bootstrap
         $(".container select").selectpicker();
         $('[data-toggle="popover"]').popover();
+
+        // When switchLangWithShift's value changed, update switchLangWithWhichShift's disabled property
+        $("#switchLangWithShift").on("click", function() {
+            $("#switchLangWithWhichShift").prop("disabled", !this.checked).selectpicker('refresh');
+        });
 
         // Bind shift action event
         $("#switchLangWithShift").on("click", function() {
@@ -194,6 +207,7 @@ $(function() {
         $("#shiftMoveCursor").on("click", function() {
             if (this.checked) {
                 $("#switchLangWithShift").prop("checked", false)
+                $("#switchLangWithWhichShift").prop("disabled", true).selectpicker('refresh');
             };
         });
 


### PR DESCRIPTION
- 當「使用 Shift 切換中英文模式」的選項啟用時，可以再進一步設定要使用那一邊的 Shift 來切換中英文模式，增加了以下三種選項：
    - 左右兩邊都使用
    - 僅使用左 Shift
    - 僅使用右 Shift

新酷音 (chewing)
---
![chewing](https://user-images.githubusercontent.com/16042676/147202661-b2ef8abc-12dd-48dc-abf8-e8d27bd6c51d.png)

除了新酷音、中洲韻、及 emoji 以外的所有輸入法 (cin-based)
---
![cinbase](https://user-images.githubusercontent.com/16042676/147202678-a2466365-dcb5-4eeb-b568-5bdc84106548.png)


Closes #53
Closes #386
Closes #457
Closes #661