### PR TITLE
Improve uninstaller

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -176,7 +176,7 @@ Function uninstallOldVersion
 
 			Delete "$INSTDIR\version.txt"
 			Delete "$INSTDIR\Uninstall.exe"
-			RMDir "$INSTDIR"
+			RMDir /REBOOTOK "$INSTDIR"
 
 			${If} ${RebootFlag}
 				MessageBox MB_YESNO "$(MB_REBOOT_REQUIRED)" IDNO +3
@@ -645,7 +645,7 @@ Section "Uninstall"
 
 	Delete "$INSTDIR\version.txt"
 	Delete "$INSTDIR\Uninstall.exe"
-	RMDir "$INSTDIR"
+	RMDir /REBOOTOK "$INSTDIR"
 
 	${If} ${RebootFlag}
 		MessageBox MB_YESNO "$(MB_REBOOT_REQUIRED)" IDNO +3

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -161,7 +161,7 @@ Function uninstallOldVersion
 			; Try to terminate running PIMELauncher and the server process
 			; Otherwise we cannot replace it.
 			ExecWait '"$INSTDIR\PIMELauncher.exe" /quit'
-
+			Sleep 1000
 			Delete /REBOOTOK "$INSTDIR\PIMELauncher.exe"
 
             Delete "$INSTDIR\backends.json"
@@ -632,6 +632,7 @@ Section "Uninstall"
 	; Try to terminate running PIMELauncher and the server process
 	; Otherwise we cannot replace it.
 	ExecWait '"$INSTDIR\PIMELauncher.exe" /quit'
+	Sleep 1000
 	Delete /REBOOTOK "$INSTDIR\PIMELauncher.exe"
 
 	RMDir /REBOOTOK /r "$INSTDIR\x86"

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -124,7 +124,7 @@ Function uninstallOldVersion
 			; Remove the launcher from auto-start
 			DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\PIME"
 			DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "PIMELauncher"
-			DeleteRegKey /ifempty HKLM "Software\PIME"
+			DeleteRegKey HKLM "Software\PIME"
 
 			; Unregister COM objects (NSIS UnRegDLL command is broken and cannot be used)
 			ExecWait '"$SYSDIR\regsvr32.exe" /u /s "$INSTDIR\x86\PIMETextService.dll"'
@@ -620,7 +620,7 @@ Section "Uninstall"
 	; Remove the launcher from auto-start
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\PIME"
 	DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "PIMELauncher"
-	DeleteRegKey /ifempty HKLM "Software\PIME"
+	DeleteRegKey HKLM "Software\PIME"
 
 	; Unregister COM objects (NSIS UnRegDLL command is broken and cannot be used)
 	ExecWait '"$SYSDIR\regsvr32.exe" /u /s "$INSTDIR\x86\PIMETextService.dll"'

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -613,6 +613,10 @@ SectionEnd
 
 ;Uninstaller Section
 Section "Uninstall"
+	${If} ${RunningX64}
+		SetRegView 64 ; disable registry redirection and use 64 bit Windows registry directly
+	${EndIf}
+
 	; Remove the launcher from auto-start
 	DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\PIME"
 	DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "PIMELauncher"
@@ -621,7 +625,6 @@ Section "Uninstall"
 	; Unregister COM objects (NSIS UnRegDLL command is broken and cannot be used)
 	ExecWait '"$SYSDIR\regsvr32.exe" /u /s "$INSTDIR\x86\PIMETextService.dll"'
 	${If} ${RunningX64}
-		SetRegView 64 ; disable registry redirection and use 64 bit Windows registry directly
 		ExecWait '"$SYSDIR\regsvr32.exe" /u /s "$INSTDIR\x64\PIMETextService.dll"'
 		RMDir /REBOOTOK /r "$INSTDIR\x64"
 	${EndIf}


### PR DESCRIPTION
改善了一些解除安裝的機制：

- 修正在 64 位元系統下、解除安裝後「PIME 輸入法」仍然會出現於「應用程式與功能」列表中的問題 (Close #676)
- 在 `PIMELauncher.exe /quit` 執行後，先等待一秒，再試圖移除 `PIMELauncher.exe`
  - 這麼做的目的是減少「`PIMELauncher.exe` 來不及 quit、被 NSIS uninstaller 視為正在執行中無法立即刪除、須透過重開機來進行刪除」的情況
  - 透過減少需要重開機的情況發生，能讓解除安裝的體驗變得更好（尤其是在升級 PIME 版本、重新安裝 PIME 的時候）
- 確保 `C:\Program Files (x86)\PIME` 資料夾，在解除安裝後會被完整移除
- 確保 `HKLM\Software\PIME` Registry Key，在解除安裝後會被完整移除