### PR TITLE
Improve installer

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -307,8 +307,8 @@ Function ensureVCRedist
 			${OrIfNot} ${FileExists} "$SYSDIR\msvcp140.dll"
 				MessageBox MB_YESNO|MB_ICONQUESTION $(DOWNLOAD_VCREDIST_QUESTION) IDYES +2
 					Abort ; this is skipped if the user select Yes
-				; Download latest VC++ Redistributable (x86 version)
-				inetc::get "https://aka.ms/vs/17/release/vc_redist.x86.exe" "$TEMP\vc_redist.x86.exe"
+				; Download latest VC++ Redistributable (x64 version)
+				inetc::get "https://aka.ms/vs/17/release/vc_redist.x64.exe" "$TEMP\vc_redist.x64.exe"
 				Pop $R0 ; Get the return value
 				${If} $R0 != "OK"
 					MessageBox MB_ICONSTOP|MB_OK $(DOWNLOAD_VCREDIST_FAILED_MESSAGE)
@@ -316,10 +316,7 @@ Function ensureVCRedist
 				${EndIf}
 
 				; Run vcredist installer
-				ExecWait "$TEMP\vc_redist.x86.exe" $0
-
-				; Enable X64 FS Redirection to let $SYSDIR point to C:\Windows\SysWOW64
-				${EnableX64FSRedirection}
+				ExecWait "$TEMP\vc_redist.x64.exe" $0
 
 				; Check again if we have latest VC++ Redistributable
 				${IfNot} ${FileExists} "$SYSDIR\ucrtbase.dll"

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -1,4 +1,4 @@
-;
+﻿;
 ;	Copyright (C) 2013 - 2016 Hong Jen Yee (PCMan) <pcman.tw@gmail.com>
 ;
 ;	This library is free software; you can redistribute it and/or
@@ -287,9 +287,9 @@ Function .onInstFailed
 FunctionEnd
 
 Function ensureVCRedist
-    ; Check if we have VC++ 2015 Redistributable
-    ; Reference: https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
-    ;            https://docs.python.org/3/using/windows.html#embedded-distribution
+	; Check if we have latest VC++ Redistributable
+	; Reference: https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/
+	;            https://docs.python.org/3/using/windows.html#embedded-distribution
 	${IfNot} ${FileExists} "$SYSDIR\ucrtbase.dll"
 	${OrIfNot} ${FileExists} "$SYSDIR\msvcp140.dll"
 		${If} ${RunningX64}
@@ -305,26 +305,26 @@ Function ensureVCRedist
 			${DisableX64FSRedirection}
 			${IfNot} ${FileExists} "$SYSDIR\ucrtbase.dll"
 			${OrIfNot} ${FileExists} "$SYSDIR\msvcp140.dll"
-				MessageBox MB_YESNO|MB_ICONQUESTION $(DOWNLOAD_VC2015_QUESTION) IDYES +2
+				MessageBox MB_YESNO|MB_ICONQUESTION $(DOWNLOAD_VCREDIST_QUESTION) IDYES +2
 					Abort ; this is skipped if the user select Yes
-				; Download VC++ 2015 Redistributable (x86 version)
-				inetc::get "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe" "$TEMP\vc2015_redist.x86.exe"
-				Pop $R0 ;Get the return value
+				; Download latest VC++ Redistributable (x86 version)
+				inetc::get "https://aka.ms/vs/17/release/vc_redist.x86.exe" "$TEMP\vc_redist.x86.exe"
+				Pop $R0 ; Get the return value
 				${If} $R0 != "OK"
-					MessageBox MB_ICONSTOP|MB_OK $(DOWNLOAD_VC2015_FAILED_MESSAGE)
+					MessageBox MB_ICONSTOP|MB_OK $(DOWNLOAD_VCREDIST_FAILED_MESSAGE)
 					Abort
 				${EndIf}
 
 				; Run vcredist installer
-				ExecWait "$TEMP\vc2015_redist.x86.exe" $0
+				ExecWait "$TEMP\vc_redist.x86.exe" $0
 
 				; Enable X64 FS Redirection to let $SYSDIR point to C:\Windows\SysWOW64
 				${EnableX64FSRedirection}
 
-				; Check again if we have VC++ 2015 Redistributable
+				; Check again if we have latest VC++ Redistributable
 				${IfNot} ${FileExists} "$SYSDIR\ucrtbase.dll"
 				${OrIfNot} ${FileExists} "$SYSDIR\msvcp140.dll"
-					MessageBox MB_ICONSTOP|MB_OK $(INST_VC2015_FAILED_MESSAGE)
+					MessageBox MB_ICONSTOP|MB_OK $(INST_VCREDIST_FAILED_MESSAGE)
 					ExecShell "open" "https://support.microsoft.com/en-us/kb/2999226"
 					Abort
 				${EndIf}
@@ -333,23 +333,23 @@ Function ensureVCRedist
 			; Change X64 FS Redirection back to default state
 			${EnableX64FSRedirection}
 		${Else}
-			MessageBox MB_YESNO|MB_ICONQUESTION $(DOWNLOAD_VC2015_QUESTION) IDYES +2
+			MessageBox MB_YESNO|MB_ICONQUESTION $(DOWNLOAD_VCREDIST_QUESTION) IDYES +2
 				Abort ; this is skipped if the user select Yes
-			; Download VC++ 2015 Redistributable (x86 version)
-			inetc::get "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe" "$TEMP\vc2015_redist.x86.exe"
-			Pop $R0 ;Get the return value
+			; Download latest VC++ Redistributable (x86 version)
+			inetc::get "https://aka.ms/vs/17/release/vc_redist.x86.exe" "$TEMP\vc_redist.x86.exe"
+			Pop $R0 ; Get the return value
 			${If} $R0 != "OK"
-				MessageBox MB_ICONSTOP|MB_OK $(DOWNLOAD_VC2015_FAILED_MESSAGE)
+				MessageBox MB_ICONSTOP|MB_OK $(DOWNLOAD_VCREDIST_FAILED_MESSAGE)
 				Abort
 			${EndIf}
 
 			; Run vcredist installer
-			ExecWait "$TEMP\vc2015_redist.x86.exe" $0
+			ExecWait "$TEMP\vc_redist.x86.exe" $0
 
-			; Check again if we have VC++ 2015 Redistributable
+			; Check again if we have latest VC++ Redistributable
 			${IfNot} ${FileExists} "$SYSDIR\ucrtbase.dll"
 			${OrIfNot} ${FileExists} "$SYSDIR\msvcp140.dll"
-				MessageBox MB_ICONSTOP|MB_OK $(INST_VC2015_FAILED_MESSAGE)
+				MessageBox MB_ICONSTOP|MB_OK $(INST_VCREDIST_FAILED_MESSAGE)
 				ExecShell "open" "https://support.microsoft.com/en-us/kb/2999226"
 				Abort
 			${EndIf}
@@ -364,8 +364,8 @@ InstType "$(INST_TYPE_FULL)"
 ;Installer Sections
 Section $(SECTION_MAIN) SecMain
 	SectionIn 1 2 RO
-    ; Ensure that we have VC++ 2015 runtime (for python 3.5)
-    Call ensureVCRedist
+	; Ensure that we have latest VC++ runtime (for python)
+	Call ensureVCRedist
 
 	; TODO: may be we can automatically rebuild the dlls here.
 	; http://stackoverflow.com/questions/24580/how-do-you-automate-a-visual-studio-build

--- a/installer/locale/English.nsh
+++ b/installer/locale/English.nsh
@@ -17,7 +17,7 @@
 !insertmacro LANG_STRING UNINSTALL_OLD "An older version of PIME has been detected. Do you want to remove the old version and continue installing the new version?"
 !insertmacro LANG_STRING DOWNLOAD_VCREDIST_QUESTION "This program requires the VC++ Redistributable to run. Would you like to automatically download and install it?"
 !insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "Failed to download VC++ Redistributable try again later, or install it manually"
-!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable (x86) was not installed correctly. Refer to the relevant Microsoft documentation for updates."
+!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable was not installed correctly. Refer to the relevant Microsoft documentation for updates."
 
 !insertmacro LANG_STRING SECTION_MAIN "PIME input method platform"
 !insertmacro LANG_STRING PYTHON_SECTION_GROUP "Input method modules with Python"

--- a/installer/locale/English.nsh
+++ b/installer/locale/English.nsh
@@ -15,9 +15,9 @@
 !insertmacro LANG_STRING REBOOT_QUESTION "The installation failed and could no be completed.$\r$\nA file may be in use, that prevents it from being deleted or overwritten.$\n$\nIt is recommended that you reboot the system and run the installer again.$\r$\nDo you want to reboot now? (Select $\"No$\" if you want to reboot at a later time)"
 !insertmacro LANG_STRING INST_FAILED_MESSAGE "The installation failed and could no be completed.$\n$\rA file may be in use, that prevents it from being deleted or overwritten.$\n$\nIt is recommended that you reboot the system and run the installer again."
 !insertmacro LANG_STRING UNINSTALL_OLD "An older version of PIME has been detected. Do you want to remove the old version and continue installing the new version?"
-!insertmacro LANG_STRING DOWNLOAD_VC2015_QUESTION "This program requires the VC++ 2015 Runtime update to run. Would you like to automatically download and install it?"
-!insertmacro LANG_STRING DOWNLOAD_VC2015_FAILED_MESSAGE "Failed to download VC++ 2015 Runtime (x86). Please try again later, or install it manually"
-!insertmacro LANG_STRING INST_VC2015_FAILED_MESSAGE "VC++ 2015 runtime (x86) was not installed correctly. Refer to the relevant Microsoft documentation for updates."
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_QUESTION "This program requires the VC++ Redistributable to run. Would you like to automatically download and install it?"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "Failed to download VC++ Redistributable try again later, or install it manually"
+!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable (x86) was not installed correctly. Refer to the relevant Microsoft documentation for updates."
 
 !insertmacro LANG_STRING SECTION_MAIN "PIME input method platform"
 !insertmacro LANG_STRING PYTHON_SECTION_GROUP "Input method modules with Python"

--- a/installer/locale/SimpChinese.nsh
+++ b/installer/locale/SimpChinese.nsh
@@ -15,9 +15,9 @@
 !insertmacro LANG_STRING REBOOT_QUESTION "安装发生错误，无法完成。$\r$\n有时是有文件正在使用中，暂时无法删除或覆写。$\n$\n建议重新开机后，再次执行安装程序。$\r$\n你要立即重新开机吗？ (若你想要在稍后才重新开机请选择「否」)"
 !insertmacro LANG_STRING INST_FAILED_MESSAGE "安装发生错误，无法完成。$\n$\n有时是有文件正在使用中，暂时无法删除或覆写。$\n$\n建议重新开机后，再次执行安装程序。"
 !insertmacro LANG_STRING UNINSTALL_OLD "侦测到已安装旧版，是否要移除旧版后继续安装新版？"
-!insertmacro LANG_STRING DOWNLOAD_VC2015_QUESTION "这个程序需要微软 VC++ 2015 runtime 更新才能运作，要自动下载安装？"
-!insertmacro LANG_STRING DOWNLOAD_VC2015_FAILED_MESSAGE "无法正确下载，请稍后再试，或手动安装 VC++ 2015 runtime (x86)"
-!insertmacro LANG_STRING INST_VC2015_FAILED_MESSAGE "VC++ 2015 runtime (x86) 并未正确安装，请参阅相关微软文档进行更新。"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_QUESTION "这个程序需要 微软 VC++ Redistributable 更新才能运作，要自动下载安装？"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "无法正确下载，请稍后再试，或手动安装 VC++ Redistributable (x86)"
+!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable (x86) 并未正确安装，请参阅相关微软文档进行更新。"
 
 !insertmacro LANG_STRING SECTION_MAIN "PIME 输入法平台"
 !insertmacro LANG_STRING PYTHON_SECTION_GROUP "Python 输入法模块"

--- a/installer/locale/SimpChinese.nsh
+++ b/installer/locale/SimpChinese.nsh
@@ -16,8 +16,8 @@
 !insertmacro LANG_STRING INST_FAILED_MESSAGE "安装发生错误，无法完成。$\n$\n有时是有文件正在使用中，暂时无法删除或覆写。$\n$\n建议重新开机后，再次执行安装程序。"
 !insertmacro LANG_STRING UNINSTALL_OLD "侦测到已安装旧版，是否要移除旧版后继续安装新版？"
 !insertmacro LANG_STRING DOWNLOAD_VCREDIST_QUESTION "这个程序需要 微软 VC++ Redistributable 更新才能运作，要自动下载安装？"
-!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "无法正确下载，请稍后再试，或手动安装 VC++ Redistributable (x86)"
-!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable (x86) 并未正确安装，请参阅相关微软文档进行更新。"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "无法正确下载，请稍后再试，或手动安装 VC++ Redistributable"
+!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable 并未正确安装，请参阅相关微软文档进行更新。"
 
 !insertmacro LANG_STRING SECTION_MAIN "PIME 输入法平台"
 !insertmacro LANG_STRING PYTHON_SECTION_GROUP "Python 输入法模块"

--- a/installer/locale/TradChinese.nsh
+++ b/installer/locale/TradChinese.nsh
@@ -16,8 +16,8 @@
 !insertmacro LANG_STRING INST_FAILED_MESSAGE "安裝發生錯誤，無法完成。$\n$\n有時是有檔案正在使用中，暫時無法刪除或覆寫。$\n$\n建議重新開機後，再次執行安裝程式。"
 !insertmacro LANG_STRING UNINSTALL_OLD "偵測到已安裝舊版，是否要移除舊版後繼續安裝新版？"
 !insertmacro LANG_STRING DOWNLOAD_VCREDIST_QUESTION "這個程式需要 微軟 VC++ Redistributable 更新才能運作，要自動下載安裝？"
-!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "無法正確下載，請稍後再試，或手動安裝 VC++ Redistributable (x86)"
-!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable (x86) 並未正確安裝，請參閱相關微軟文件進行更新。"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "無法正確下載，請稍後再試，或手動安裝 VC++ Redistributable"
+!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable 並未正確安裝，請參閱相關微軟文件進行更新。"
 
 !insertmacro LANG_STRING SECTION_MAIN "PIME 輸入法平台"
 !insertmacro LANG_STRING PYTHON_SECTION_GROUP "Python 輸入法模組"

--- a/installer/locale/TradChinese.nsh
+++ b/installer/locale/TradChinese.nsh
@@ -15,9 +15,9 @@
 !insertmacro LANG_STRING REBOOT_QUESTION "安裝發生錯誤，無法完成。$\r$\n有時是有檔案正在使用中，暫時無法刪除或覆寫。$\n$\n建議重新開機後，再次執行安裝程式。$\r$\n你要立即重新開機嗎？ (若你想要在稍後才重新開機請選擇「否」)"
 !insertmacro LANG_STRING INST_FAILED_MESSAGE "安裝發生錯誤，無法完成。$\n$\n有時是有檔案正在使用中，暫時無法刪除或覆寫。$\n$\n建議重新開機後，再次執行安裝程式。"
 !insertmacro LANG_STRING UNINSTALL_OLD "偵測到已安裝舊版，是否要移除舊版後繼續安裝新版？"
-!insertmacro LANG_STRING DOWNLOAD_VC2015_QUESTION "這個程式需要微軟 VC++ 2015 runtime 更新才能運作，要自動下載安裝？"
-!insertmacro LANG_STRING DOWNLOAD_VC2015_FAILED_MESSAGE "無法正確下載，請稍後再試，或手動安裝 VC++ 2015 runtime (x86)"
-!insertmacro LANG_STRING INST_VC2015_FAILED_MESSAGE "VC++ 2015 runtime (x86) 並未正確安裝，請參閱相關微軟文件進行更新。"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_QUESTION "這個程式需要 微軟 VC++ Redistributable 更新才能運作，要自動下載安裝？"
+!insertmacro LANG_STRING DOWNLOAD_VCREDIST_FAILED_MESSAGE "無法正確下載，請稍後再試，或手動安裝 VC++ Redistributable (x86)"
+!insertmacro LANG_STRING INST_VCREDIST_FAILED_MESSAGE "VC++ Redistributable (x86) 並未正確安裝，請參閱相關微軟文件進行更新。"
 
 !insertmacro LANG_STRING SECTION_MAIN "PIME 輸入法平台"
 !insertmacro LANG_STRING PYTHON_SECTION_GROUP "Python 輸入法模組"


### PR DESCRIPTION
改善了一些安裝過程的機制：

- 在 64 位元系統下，安裝檔會先偵測是否有 32 位元版本 Visual C++ Redistributable，再偵測是否有 64 位元版本 Visual C++ Redistributable，如果都沒有偵測到才會進行「自動下載並安裝微軟 VC++ 2015 runtime」的步驟 (Close #679)
- 「自動下載並安裝微軟 VC++ runtime」的步驟，從原本是固定下載「VC++ 2015 Redistributable x86 版本」改為：
  - 下載並安裝最新支援版本（目前是 VC++ 2015-2022 Redistributable）
  - 在 64 位元系統下，安裝的會是 x64 版本的