### PR TITLE
Upgrade repolevedavaj/install-nsis to v1.0.2, fix NSIS download url.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 21.x
       - name: Use Install NSIS
-        uses: repolevedavaj/install-nsis@v1.0.1
+        uses: repolevedavaj/install-nsis@v1.0.2
         with:
           nsis-version: 3.08
       - name: Run build.bat


### PR DESCRIPTION
Why should we upgrade to v1.0.2? Because the nsis download url changed, so new CI build would fail.
An example: https://github.com/dongyuwei/Hallelujah-Windows/actions/runs/10504464610/job/29100181076

```
Run repolevedavaj/install-nsis@v1.0.1
Run Invoke-WebRequest https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/3.08/nsis-3.08-setup.exe -OutFile C:\WINDOWS\Temp\nsis-3.08-setup.exe
Invoke-Expression: D:\a\_temp\f65df[4](https://github.com/dongyuwei/Hallelujah-Windows/actions/runs/10504464610/job/29100181076#step:3:5)a4-4347-43c6-97ff-c27cdc9ae440.ps1:3
Line |
   3 |  Invoke-Expression "& C:\WINDOWS\Temp\nsis-3.0[8](https://github.com/dongyuwei/Hallelujah-Windows/actions/runs/10504464610/job/29100181076#step:3:10)-setup.exe \S"
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Program 'nsis-3.08-setup.exe' failed to run: An error occurred trying to start process
     | 'C:\WINDOWS\Temp\nsis-3.08-setup.exe' with working directory 'D:\a\Hallelujah-Windows\Hallelujah-Windows'. The
     | file or directory is corrupted and unreadable.At line:1 char:1 + & C:\WINDOWS\Temp\nsis-3.08-setup.exe \S +
     | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~.
Error: Process completed with exit code 1.
```