### PR TITLE
Update the NSIS instealler to repolevedavaj/install-nsis@v1.2.0 in the CI configs.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 21.x
       - name: Use Install NSIS
-        uses: repolevedavaj/install-nsis@v1.0.2
+        uses: repolevedavaj/install-nsis@v1.2.0
         with:
           nsis-version: 3.08
       - name: Run build.bat


### PR DESCRIPTION
This fixes NSIS download issues.